### PR TITLE
Integrated compass tracking camera orientation, not player orientation

### DIFF
--- a/RichMatt/Assets/Scripts/Compass.cs
+++ b/RichMatt/Assets/Scripts/Compass.cs
@@ -30,16 +30,17 @@ public class Compass : MonoBehaviour
 		CompassImage.uvRect = new Rect(Player.localEulerAngles.y / 360, 0, 1, 1);
 
 		// Get a copy of your forward vector
-		Vector3 forward = Player.transform.forward;
+		Vector3 facing = Camera.main.transform.forward; // camera transform, not player
 
 		// Zero out the y component of your forward vector to only get the direction in the X,Z plane
-		forward.y = 0;
+		facing.y = 0;
 
-		//Clamp our angles to specified degree increments
-		float headingAngle = Quaternion.LookRotation(forward).eulerAngles.y;//what is the player's angle
+        //get cangle between direction facing and 'north', world forward
+        float headingAngle = Vector3.Angle(facing, Vector3.forward);
 		headingAngle = (int)degreeInc * Mathf.RoundToInt(headingAngle / (int)degreeInc  );
 
-        if (ordinalLetters)//convert the numbers to letters if pointing towards a direction (N/E/S/W)
+        //convert the numbers to letters if pointing towards a direction (N/E/S/W)
+        if (ordinalLetters)
         {
             ConvertAngleToLetter( (int)headingAngle );
         }

--- a/RichMatt/Assets/Scripts/SkyDiveTesting.cs
+++ b/RichMatt/Assets/Scripts/SkyDiveTesting.cs
@@ -93,8 +93,9 @@ public class SkyDiveTesting : MonoBehaviour
 
     void Start()
     {
+        this.enabled = false;//enable by calling BeginSkyDiving();
        
-        //verify input
+        //verify developer input
         if (terminalVelocity > 0)
         {
             terminalVelocity *= -1;//invert if above 0


### PR DESCRIPTION
added line to prevent errors in skydiving

compass now checks for camera facing compared to 'north', Vector3.forward.